### PR TITLE
No longer requires the use of `th` elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ jQuery plugin to serialize HTML tables into javascript objects.
 ## Features
 - Automatically finds column headings
   - Override found column headings by using `data-column-name="overridden column name"`
+  - Falls back on first row when no `th` elements are found
 - Override cell values by using `data-cell-value="new value"`
 - Ignorable columns
 - Not confused by nested tables

--- a/lib/jquery.tabletojson.js
+++ b/lib/jquery.tabletojson.js
@@ -1,13 +1,13 @@
 /**
- * Table To JSON
+ * tabletojson
  * jQuery plugin that reads an HTML table and returns a javascript object representing the values and columns of the table
  *
  * @author Daniel White
  * @copyright Daniel White 2013
  * @license MIT <https://github.com/lightswitch05/table-to-json/blob/master/MIT-LICENSE>
  * @link https://github.com/lightswitch05/table-to-json
- * @module Table To JSON
- * @version 0.3.0
+ * @module tabletojson
+ * @version 0.4.0
  */
 
 (function( $ ) {
@@ -21,40 +21,55 @@
     opts = $.extend(defaults, opts);
 
     // Gather headings
-    var headings = [];
-    this.find("tr > th").each(function(colIndex, col) {
-      if($.inArray(colIndex, opts.ignoreColNum) === -1) {
-        if($(col).data("column-name") !== undefined && $(col).data("column-name") != null) {
-          headings[colIndex] = $(col).data("column-name");
-        } else {
-          headings[colIndex] = $.trim($(col).text());
-        }
-      } else {
-        headings[colIndex] = null;
-      }
-    });
-
-    // Gather values
-    var values = [];
-    this.children("tbody").children("tr:has(td)")
-    .filter(function(index){
-      // Only get rows with values, no headings
-      return $(this).children("th").length === 0;
-    }).each(function(rowIndex, row) {
-      if( $(row).is(':visible') || !opts.ignoreHiddenRows ) {
-        values[rowIndex] = {};
-        $(row).children("td").each(function(colIndex, col) {
-          if( headings[colIndex] !== undefined && headings[colIndex] !== null){
-            if($(col).data("cell-value") !== undefined && $(col).data("cell-value") !== null) {
-              values[rowIndex][ headings[colIndex] ] = $(col).data("cell-value");
-            } else {
-              values[rowIndex][ headings[colIndex] ] = $.trim($(col).text());
-            }
+    var getHeadings = function(self, filter) {
+      var headings = [];
+      self.find(filter).each(function(colIndex, col) {
+        if($.inArray(colIndex, opts.ignoreColNum) === -1) {
+          if($(col).data("column-name") !== undefined && $(col).data("column-name") != null) {
+            headings[colIndex] = $(col).data("column-name");
+          } else {
+            headings[colIndex] = $.trim($(col).text());
           }
-        });
-      }
-    });
-    return values;
+        } else {
+          headings[colIndex] = null;
+        }
+      });
+      return headings;
+    };
+    
+    var getValues = function(self, headings, treatFirstRowAsHeadings) {
+      var values = [];
+      self.children("tbody").children("tr:has(td)")
+      .filter(function(index){
+        // Only get rows with values, no headings
+        return $(this).children("th").length === 0;
+      }).each(function(rowIndex, row) {
+        if( !treatFirstRowAsHeadings || rowIndex !== 0) {
+          if( $(row).is(':visible') || !opts.ignoreHiddenRows ) {
+            values[values.length] = {};
+            $(row).children("td").each(function(colIndex, col) {
+              if( headings[colIndex] !== undefined && headings[colIndex] !== null){
+                if($(col).data("cell-value") !== undefined && $(col).data("cell-value") !== null) {
+                  values[values.length - 1][ headings[colIndex] ] = $(col).data("cell-value");
+                } else {
+                  values[values.length - 1][ headings[colIndex] ] = $.trim($(col).text());
+                }
+              }
+            });
+          }
+        }
+      });
+      return values;
+    };
+
+    // Run
+    var treatFirstRowAsHeadings = false;
+    var headings = getHeadings(this, "tr:first > th");
+    if( headings.length === 0 ) {
+      treatFirstRowAsHeadings = true;
+      headings = getHeadings(this, "tr:first > td");
+    }
+    return getValues(this, headings, treatFirstRowAsHeadings);
   };
 })( jQuery );
 

--- a/lib/jquery.tabletojson.min.js
+++ b/lib/jquery.tabletojson.min.js
@@ -1,12 +1,12 @@
 /**
- * Table To JSON
+ * tabletojson
  * jQuery plugin that reads an HTML table and returns a javascript object representing the values and columns of the table
  *
  * @author Daniel White
  * @copyright Daniel White 2013
  * @license MIT <https://github.com/lightswitch05/table-to-json/blob/master/MIT-LICENSE>
  * @link https://github.com/lightswitch05/table-to-json
- * @module Table To JSON
- * @version 0.3.0
+ * @module tabletojson
+ * @version 0.4.0
  */
-(function(e){e.fn.tableToJSON=function(t){var n={ignoreColNum:[],ignoreHiddenRows:!0};t=e.extend(n,t);var r=[];this.find("tr > th").each(function(n,i){e.inArray(n,t.ignoreColNum)===-1?e(i).data("column-name")!==undefined&&e(i).data("column-name")!=null?r[n]=e(i).data("column-name"):r[n]=e.trim(e(i).text()):r[n]=null});var i=[];return this.children("tbody").children("tr:has(td)").filter(function(t){return e(this).children("th").length===0}).each(function(n,s){if(e(s).is(":visible")||!t.ignoreHiddenRows)i[n]={},e(s).children("td").each(function(t,s){r[t]!==undefined&&r[t]!==null&&(e(s).data("cell-value")!==undefined&&e(s).data("cell-value")!==null?i[n][r[t]]=e(s).data("cell-value"):i[n][r[t]]=e.trim(e(s).text()))})}),i}})(jQuery);
+(function(e){e.fn.tableToJSON=function(t){var n={ignoreColNum:[],ignoreHiddenRows:!0};t=e.extend(n,t);var r=function(n,r){var i=[];return n.find(r).each(function(n,r){e.inArray(n,t.ignoreColNum)===-1?e(r).data("column-name")!==undefined&&e(r).data("column-name")!=null?i[n]=e(r).data("column-name"):i[n]=e.trim(e(r).text()):i[n]=null}),i},i=function(n,r,i){var s=[];return n.children("tbody").children("tr:has(td)").filter(function(t){return e(this).children("th").length===0}).each(function(n,o){if(!i||n!==0)if(e(o).is(":visible")||!t.ignoreHiddenRows)s[s.length]={},e(o).children("td").each(function(t,n){r[t]!==undefined&&r[t]!==null&&(e(n).data("cell-value")!==undefined&&e(n).data("cell-value")!==null?s[s.length-1][r[t]]=e(n).data("cell-value"):s[s.length-1][r[t]]=e.trim(e(n).text()))})}),s},s=!1,o=r(this,"tr:first > th");return o.length===0&&(s=!0,o=r(this,"tr:first > td")),i(this,o,s)}})(jQuery);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name"        : "tabletojson",
   "description" : "jQuery plugin that reads an HTML table and returns a javascript object representing the values and columns of the table",
-  "version"     : "0.3.0",
+  "version"     : "0.4.0",
   "homepage"    : "https://github.com/lightswitch05/table-to-json",
   "main"        : "lib/jquery.tabletojson.js",
   "repository": {

--- a/src/jquery.tabletojson.js
+++ b/src/jquery.tabletojson.js
@@ -9,40 +9,55 @@
     opts = $.extend(defaults, opts);
 
     // Gather headings
-    var headings = [];
-    this.find("tr > th").each(function(colIndex, col) {
-      if($.inArray(colIndex, opts.ignoreColNum) === -1) {
-        if($(col).data("column-name") !== undefined && $(col).data("column-name") != null) {
-          headings[colIndex] = $(col).data("column-name");
-        } else {
-          headings[colIndex] = $.trim($(col).text());
-        }
-      } else {
-        headings[colIndex] = null;
-      }
-    });
-
-    // Gather values
-    var values = [];
-    this.children("tbody").children("tr:has(td)")
-    .filter(function(index){
-      // Only get rows with values, no headings
-      return $(this).children("th").length === 0;
-    }).each(function(rowIndex, row) {
-      if( $(row).is(':visible') || !opts.ignoreHiddenRows ) {
-        values[rowIndex] = {};
-        $(row).children("td").each(function(colIndex, col) {
-          if( headings[colIndex] !== undefined && headings[colIndex] !== null){
-            if($(col).data("cell-value") !== undefined && $(col).data("cell-value") !== null) {
-              values[rowIndex][ headings[colIndex] ] = $(col).data("cell-value");
-            } else {
-              values[rowIndex][ headings[colIndex] ] = $.trim($(col).text());
-            }
+    var getHeadings = function(self, filter) {
+      var headings = [];
+      self.find(filter).each(function(colIndex, col) {
+        if($.inArray(colIndex, opts.ignoreColNum) === -1) {
+          if($(col).data("column-name") !== undefined && $(col).data("column-name") != null) {
+            headings[colIndex] = $(col).data("column-name");
+          } else {
+            headings[colIndex] = $.trim($(col).text());
           }
-        });
-      }
-    });
-    return values;
+        } else {
+          headings[colIndex] = null;
+        }
+      });
+      return headings;
+    };
+    
+    var getValues = function(self, headings, treatFirstRowAsHeadings) {
+      var values = [];
+      self.children("tbody").children("tr:has(td)")
+      .filter(function(index){
+        // Only get rows with values, no headings
+        return $(this).children("th").length === 0;
+      }).each(function(rowIndex, row) {
+        if( !treatFirstRowAsHeadings || rowIndex !== 0) {
+          if( $(row).is(':visible') || !opts.ignoreHiddenRows ) {
+            values[values.length] = {};
+            $(row).children("td").each(function(colIndex, col) {
+              if( headings[colIndex] !== undefined && headings[colIndex] !== null){
+                if($(col).data("cell-value") !== undefined && $(col).data("cell-value") !== null) {
+                  values[values.length - 1][ headings[colIndex] ] = $(col).data("cell-value");
+                } else {
+                  values[values.length - 1][ headings[colIndex] ] = $.trim($(col).text());
+                }
+              }
+            });
+          }
+        }
+      });
+      return values;
+    };
+
+    // Run
+    var treatFirstRowAsHeadings = false;
+    var headings = getHeadings(this, "tr:first > th");
+    if( headings.length === 0 ) {
+      treatFirstRowAsHeadings = true;
+      headings = getHeadings(this, "tr:first > td");
+    }
+    return getValues(this, headings, treatFirstRowAsHeadings);
   };
 })( jQuery );
 

--- a/tabletojson.jquery.json
+++ b/tabletojson.jquery.json
@@ -8,7 +8,7 @@
     "tabletojson",
     "json"
   ],
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Daniel White",
     "url": "http://www.developerdan.com"

--- a/test/specs/content.test.js
+++ b/test/specs/content.test.js
@@ -1,7 +1,7 @@
 module("content");
 
-/* Ignore nested tables in cells */
-test("ignore nested tables in cells", function() {
+/* Ignore nested tables in cells with just td's*/
+test("ignore nested td's in cells", function() {
   $("#qunit-fixture").html(
       "<table id='test-table'>" +
         "<tr>" +
@@ -36,8 +36,44 @@ test("ignore nested tables in cells", function() {
   deepEqual(table, expected);
 });
 
-/* Ignore nested tables in headings */
-test("ignore nested tables in headings", function() {
+/* Ignore nested tables in cells with th's and td's*/
+test("ignore nested th's and td's in cells", function() {
+  $("#qunit-fixture").html(
+      "<table id='test-table'>" +
+        "<tr>" +
+          "<th>First Name</th>" +
+          "<th>Last Name</th>" +
+          "<th>Points</th>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>Jill</td>" +
+          "<td>Smith</td>" +
+          "<td>50</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>Eve <table><tr><th>number</th></tr><tr><td>1</td></tr><tr><td>2</td></tr></table> </td>" +
+          "<td>Jackson</td>" +
+          "<td>94</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>John</td>" +
+          "<td>Doe</td>" +
+          "<td>80</td>" +
+        "</tr>" +
+      "</table>"
+    );
+
+
+  expect(1);
+  var table = $("#test-table").tableToJSON();
+  var expected = [{"First Name":"Jill", "Last Name":"Smith", "Points":"50"},
+                  {"First Name":"Eve number12", "Last Name":"Jackson", "Points":"94"},
+                  {"First Name":"John", "Last Name":"Doe", "Points":"80"}]
+  deepEqual(table, expected);
+});
+
+/* Ignore nested tables in headings with just td's*/
+test("ignore nested td's in headings", function() {
   $("#qunit-fixture").html(
       "<table id='test-table'>" +
         "<tr>" +
@@ -69,6 +105,42 @@ test("ignore nested tables in headings", function() {
   var expected = [{"First Name":"Jill", "Last Name 12":"Smith", "Points":"50"},
                   {"First Name":"Eve", "Last Name 12":"Jackson", "Points":"94"},
                   {"First Name":"John", "Last Name 12":"Doe", "Points":"80"}]
+  deepEqual(table, expected);
+});
+
+/* Ignore nested tables in headings with th's and td's*/
+test("ignore nested th's and td's in headings", function() {
+  $("#qunit-fixture").html(
+      "<table id='test-table'>" +
+        "<tr>" +
+          "<th>First Name</th>" +
+          "<th>Last Name <table><tr><th>number</th></tr><tr><td>1</td></tr><tr><td>2</td></tr></table> </th>" +
+          "<th>Points</th>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>Jill</td>" +
+          "<td>Smith</td>" +
+          "<td>50</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>Eve</td>" +
+          "<td>Jackson</td>" +
+          "<td>94</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>John</td>" +
+          "<td>Doe</td>" +
+          "<td>80</td>" +
+        "</tr>" +
+      "</table>"
+    );
+
+
+  expect(1);
+  var table = $("#test-table").tableToJSON();
+  var expected = [{"First Name":"Jill", "Last Name number12":"Smith", "Points":"50"},
+                  {"First Name":"Eve", "Last Name number12":"Jackson", "Points":"94"},
+                  {"First Name":"John", "Last Name number12":"Doe", "Points":"80"}]
   deepEqual(table, expected);
 });
 

--- a/test/specs/core.test.js
+++ b/test/specs/core.test.js
@@ -258,3 +258,41 @@ test("Include Hidden Rows", function() {
                   {"First Name":"John", "Last Name":"Doe", "Points":"80"}]
   deepEqual(table, expected);
 });
+
+/* Read first row of td's as column when there are no th's*/
+test("without any th's", function() {
+  $("#qunit-fixture").html(
+      "<table id='test-table'>" +
+        "<tr>" +
+          "<td>First Name</td>" +
+          "<td>Last Name</td>" +
+          "<td>Points</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>Jill</td>" +
+          "<td>Smith</td>" +
+          "<td>50</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>Eve</td>" +
+          "<td>Jackson</td>" +
+          "<td>94</td>" +
+        "</tr>" +
+        "<tr>" +
+          "<td>John</td>" +
+          "<td>Doe</td>" +
+          "<td>80</td>" +
+        "</tr>" +
+      "</table>"
+    );
+
+
+  expect(1);
+  var table = $("#test-table").tableToJSON({
+        ignoreHiddenRows: false
+  });
+  var expected = [{"First Name":"Jill", "Last Name":"Smith", "Points":"50"},
+                  {"First Name":"Eve", "Last Name":"Jackson", "Points":"94"},
+                  {"First Name":"John", "Last Name":"Doe", "Points":"80"}]
+  deepEqual(table, expected);
+});


### PR DESCRIPTION
Table to JSON now uses the first row as the column headings when `th`
elements are not found
